### PR TITLE
Update Schema.required to string[]

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -205,7 +205,7 @@ export namespace OpenAPI3 {
     uniqueItems?: number;
     maxProperties?: number;
     minProperties?: number;
-    required?: boolean;
+    required?: string[];
     enum?: string[];
 
     type?: string; // - Value MUST be a string. Multiple types via an array are not supported.


### PR DESCRIPTION
This should be an string[] according to https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-5.15
And at least here is used as so: https://github.com/foxel/openapi3-typescript-codegen/blob/master/templates/typescript/schema.partial.handlebars#L27